### PR TITLE
Resolve checkstyle cache miss

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -686,7 +686,6 @@ subprojects {
 
   checkstyle {
     configDirectory = rootProject.layout.projectDirectory.dir("checkstyle")
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
     configProperties = checkstyleConfigProperties("import-control.xml")
     toolVersion = versions.checkstyle
   }

--- a/build.gradle
+++ b/build.gradle
@@ -685,6 +685,7 @@ subprojects {
   }
 
   checkstyle {
+    configDirectory = rootProject.layout.projectDirectory.dir("checkstyle")
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
     configProperties = checkstyleConfigProperties("import-control.xml")
     toolVersion = versions.checkstyle
@@ -789,9 +790,7 @@ def fineTuneEclipseClasspathFile(eclipse, project) {
 }
 
 def checkstyleConfigProperties(configFileName) {
-  [importControlFile: "$rootDir/checkstyle/$configFileName",
-   suppressionsFile: "$rootDir/checkstyle/suppressions.xml",
-   headerFile: "$rootDir/checkstyle/java.header"]
+  [importControlFile: "$configFileName"]
 }
 
 // Aggregates all jacoco results into the root project directory

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -25,7 +25,7 @@
 
   <!-- header -->
   <module name="Header">
-    <property name="headerFile" value="${headerFile}" />
+    <property name="headerFile" value="${config_loc}/java.header" />
   </module>
 
   <module name="TreeWalker">
@@ -79,7 +79,7 @@
 
     <!-- dependencies -->
     <module name="ImportControl">
-      <property name="file" value="${importControlFile}"/>
+      <property name="file" value="${config_loc}/${importControlFile}"/>
     </module>
 
     <!-- whitespace -->
@@ -149,7 +149,7 @@
   </module>
 
   <module name="SuppressionFilter">
-    <property name="file" value="${suppressionsFile}"/>
+    <property name="file" value="${config_loc}/suppressions.xml"/>
   </module>
 
   <!-- Allows the use of the @SuppressWarnings annotation in the code -->


### PR DESCRIPTION
Resolves cache misses in `checkstyle` tasks due to absolute paths in `configProperties`.

Sets `configDirectory` extension property, which is made available by the `checkstyle` plugin as `${config_loc}` in the `checkstyle` xml files, as shown in the Checkstyle Gradle docs [here](https://docs.gradle.org/current/userguide/checkstyle_plugin.html#sec:checkstyle_built_in_variables). The absolute paths set in `configProperties` are then replaced by relative paths from `configDirectory`. Because the header and suppression config file names are static and only referenced once, these were removed from `configProperties` and the file names are given directly in `checkstyle.xml` 

[Task input comparison showing input differences between builds causing cache miss](https://ge.solutions-team.gradle.com/c/udumk6sv5uwbw/an5e6pclyiblm/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure)
[Task input comparison with fix applied - no differences between builds](https://ge.solutions-team.gradle.com/c/ojlblvuooowjo/rrubheuf5ex5g/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure)

### Tests

Manually verified suppressions are working as expected:
* [checkStyleMain FAILS when calling `System.exit()` in `MessageGenerator.java` with that suppression DISABLED](https://ge.solutions-team.gradle.com/s/34amuqemmyili/failure#1)
* [checkStyleMain PASSES when calling `System.exit()` in `MessageGenerator.java` with that suppression ENABLED](https://ge.solutions-team.gradle.com/s/s62zwn5gfsu54/failure)

Manually verified header check is working as expected:
* [checkStyleMain FAILS when java file is missing license header](https://ge.solutions-team.gradle.com/s/rjjqrqrmam6oq/failure#1)
